### PR TITLE
Split graphql query into chunks of 100

### DIFF
--- a/src/aura_helper.py
+++ b/src/aura_helper.py
@@ -516,25 +516,31 @@ class AuraHelper:
 		banned_fields = ["CloneSourceId"] #Not handled properly by the tool (yet?)
 		banned_types = ["ADDRESS","ANYTYPE","COMPLEXVALUE"] #Not handled properly by the tool (yet?)
 		object_fields_map = {}
-		#Formatting as follow objectInfos(apiNames:User,Account) etc...
-		formatted_object_names = json.dumps(objects,separators=(',', ':'))
-		action = AuraActionHelper.build_action(
-			'1;fields',
-			'aura://RecordUiController/ACTION$executeGraphQL',
-			{
-				'queryInput':{
-					'operationName':'getFields',
-					'query':'query getFields{uiapi{objectInfos(apiNames:%s){ApiName,fields{ApiName,dataType}}}}' % (formatted_object_names),
-					'variables':{},
+
+		# GraphQL apiNames is limited to 100 entries
+		for i in range(0, len(objects), 100):
+			batch = objects[i:i+100]
+
+			#Formatting as follow objectInfos(apiNames:User,Account) etc...
+			formatted_object_names = json.dumps(batch,separators=(',', ':'))
+			action = AuraActionHelper.build_action(
+				'1;fields',
+				'aura://RecordUiController/ACTION$executeGraphQL',
+				{
+					'queryInput':{
+						'operationName':'getFields',
+						'query':'query getFields{uiapi{objectInfos(apiNames:%s){ApiName,fields{ApiName,dataType}}}}' % (formatted_object_names),
+						'variables':{},
+					}
 				}
-			}
-		)
-		action_response = self.send_aura_bulk(action).actions_responses[0]
-		if not action_response.is_success():
-			logger.error('Error while retrieving field names with GraphQL')
-			return None
-		objects_infos = filter(None, action_response.return_value['data']['uiapi']['objectInfos'])
-		object_fields_map = {x['ApiName']: [y['ApiName'] for y in x['fields'] if y['dataType'] not in banned_types and y['ApiName'] not in banned_fields] for x in objects_infos}
+			)
+			action_response = self.send_aura_bulk(action).actions_responses[0]
+			if not action_response.is_success():
+				logger.error('Error while retrieving field names with GraphQL')
+				return None
+			print(action_response.return_value)
+			objects_infos = filter(None, action_response.return_value['data']['uiapi']['objectInfos'])
+			object_fields_map = {x['ApiName']: [y['ApiName'] for y in x['fields'] if y['dataType'] not in banned_types and y['ApiName'] not in banned_fields] for x in objects_infos}
 		return object_fields_map
 
 	def get_object_count_graphql(self, objects, make_chunks=True):

--- a/src/aura_helper.py
+++ b/src/aura_helper.py
@@ -538,9 +538,15 @@ class AuraHelper:
 			if not action_response.is_success():
 				logger.error('Error while retrieving field names with GraphQL')
 				return None
-			print(action_response.return_value)
+
 			objects_infos = filter(None, action_response.return_value['data']['uiapi']['objectInfos'])
-			object_fields_map = {x['ApiName']: [y['ApiName'] for y in x['fields'] if y['dataType'] not in banned_types and y['ApiName'] not in banned_fields] for x in objects_infos}
+			object_fields_map.update({
+				x['ApiName']: [
+					y['ApiName'] for y in x['fields']
+					if y['dataType'] not in banned_types and y['ApiName'] not in banned_fields
+				]
+				for x in objects_infos
+			})
 		return object_fields_map
 
 	def get_object_count_graphql(self, objects, make_chunks=True):


### PR DESCRIPTION
If you attempt to use this on an org with more than 100 objects the API returns an error and this causes a TypeError.

This patch splits the query into chunks of 100.

```
Traceback (most recent call last):

  File "aura-inspector/src/aura_cli.py", line 297, in <module>

    main()

    ~~~~^^

  File "aura-inspector/src/aura_cli.py", line 284, in main

    audit(url, cookies=cookies,

     ~~~~~^^^^^^^^^^^^^^^^^^^^^^

    object_list=object_list,

      ^^^^^^^^^^^^^^^^^^^^^^^^

    ...<7 lines>...

    no_gql=args.no_gql

      ^^^^^^^^^^^^^^^^^^

        )

        ^

  File "aura-inspector/src/aura_cli.py", line 65, in audit

    all_records_gql = aura.get_records_graphql(objects, records_per_action=100, fetch_all=False)

  File "aura-inspector/src/aura_helper.py", line 619, in get_records_graphql

    object_fields_map = self.get_graphql_fields_for_objects(objects)

  File "aura-inspector/src/aura_helper.py", line 536, in get_graphql_fields_for_objects

    objects_infos = filter(None, action_response.return_value['data']['uiapi']['objectInfos'])

TypeError: 'NoneType' object is not iterable
```